### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=The library for ESPert's IoT boards for using with Arduino IDE.  Esper
 category=Communication
 url=http://github.com/JimmySoftware/ESPert
 architectures=esp8266
+depends=Adafruit NeoPixel, DHT sensor library, ESP8266 and ESP32 OLED driver for SSD1306 displays, HttpClient, PubSubClient


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

NOTE: I did not add the ArduinoJson dependency because the Library Manager dependencies system currently only allows installing the newest version of the dependencies and this library is only compatible with ArduinoJson 5.x.x. In the event that this library is fixed to work with the modern ArduinoJson API, or the Library Manager dependencies system is improved to support dependency version specifications, ArduinoJson should be added to the `depends` field.